### PR TITLE
add option to use salt master as step-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,44 @@ One way to deploy certificates is in certificate mode. Then the final certs will
 ```
 nodegroups:
   step_ca_cert_mode_force_deploy_nodes: "I@step:client_config:certificate_mode:certificates and I@step:client_config:force_deploy:True"
+```
 
 That allows you to add a systemd timer/service around:
-
 ```
 salt -N step_ca_cert_mode_force_deploy_nodes state.apply step-ca
 ```
 
 That will deploy certificates and also do all the associated scriptlets.
+
+## Standalone Salt Master Step-CA Client  
+
+This formula can configures a Salt master to act as a Step-CA client. It enables the master to use an external Step CA to request tokens required for minion.  
+
+Include only the client state to your exsiting salt master:
+```
+include:
+  - step-ca.client
+```
+Set the pillar data for the Step CLI configuration:
+```
+step:
+  client_config:
+    config_dir:
+      user: 'root'
+      group: 'salt'
+      mode: '0640'
+      path: "/etc/salt/step"
+    ca:
+      url: "https://step-external.example.org"
+      root_cert:
+        fingerprint:  "9c71f3ad9d931d4c4172efcd9bfc457c157dfef34a6829ab72dbb181ed29a083"
+        path: "/etc/pki/trust/anchors/TRUSTED-STEP-EXTERNAL-CA.crt.pem"
+        password:
+          user: 'root'
+          group: 'salt'
+          mode: '0640'
+          secret: "step-external_SUPER_SECRET"
+```
 
 ## License
 


### PR DESCRIPTION
add changes in client.sls:

1. support custom step_dir
2. additional configuration for step password file 

Whit this change we can apply step-ca.client with custom path ot stand alone salt master 